### PR TITLE
Added [Experimental] warning to SaveMeshesInScene, along with additional fixes to make it less likely to break

### DIFF
--- a/Plugins/Editor/Scripts/Control/Managers/InternalCSGModelManager.Lifetime.cs
+++ b/Plugins/Editor/Scripts/Control/Managers/InternalCSGModelManager.Lifetime.cs
@@ -163,22 +163,29 @@ namespace RealtimeCSG
 			if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles)
 				return;
 
-
-			if (External == null ||
-				External.ResetCSG == null)
+			static bool ensureExternalMethodsPopulated()
 			{
-				NativeMethodBindings.RegisterUnityMethods();
-				NativeMethodBindings.RegisterExternalMethods();
-			}
+				if (External == null ||
+					External.ResetCSG == null)
+				{
+					NativeMethodBindings.RegisterUnityMethods();
+					NativeMethodBindings.RegisterExternalMethods();
+				}
 
-			if (External == null)
-            {
-				Debug.LogError("RealtimeCSG: Cannot rebuild meshes for some reason. External modules not loaded. Please save meshes into the Scene.");
-				return;
+				if (External == null)
+				{
+					Debug.LogError("RealtimeCSG: Cannot rebuild meshes for some reason. External modules not loaded. Please save meshes into the Scene.");
+					return false;
+				}
+
+				return true;
 			}
 
 			static void rebuildMeshes()
             {
+				if (!ensureExternalMethodsPopulated())
+					return;
+
 				RealtimeCSG.CSGModelManager.AllowInEditorPlayMode = true;
 				InternalCSGModelManager.Shutdown();
 				DoForcedMeshUpdate();
@@ -201,6 +208,9 @@ namespace RealtimeCSG
 					rebuildMeshes();
 				}
 			}
+
+			if (!ensureExternalMethodsPopulated())
+				return;
 
 			EditorApplication.playModeStateChanged += onPlayModeChange;
 			UnityEngine.SceneManagement.SceneManager.sceneLoaded += sceneLoaded;

--- a/Plugins/Editor/Scripts/Control/Managers/MeshInstanceManager.Build.cs
+++ b/Plugins/Editor/Scripts/Control/Managers/MeshInstanceManager.Build.cs
@@ -132,18 +132,20 @@ namespace InternalRealtimeCSG
 
                 if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
                     UnityEngine.Object.DestroyImmediate(meshContainer);
+                else
+                    meshContainer.hideFlags |= HideFlags.HideInHierarchy | HideFlags.HideInInspector;
             }
 
 
-            if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
+            var meshInstances = SceneQueryUtility.GetAllComponentsInScene<GeneratedMeshInstance>(currentScene);
+            foreach (var meshInstance in meshInstances)
             {
-                var meshInstances = SceneQueryUtility.GetAllComponentsInScene<GeneratedMeshInstance>(currentScene);
-                foreach (var meshInstance in meshInstances)
+                if (meshInstance)
                 {
-                    if (meshInstance)
-                    {
+                    if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
                         UnityEngine.Object.DestroyImmediate(meshInstance);
-                    }
+                    else
+                        meshInstance.hideFlags |= HideFlags.HideInHierarchy | HideFlags.HideInInspector;
                 }
             }
 
@@ -178,23 +180,24 @@ namespace InternalRealtimeCSG
                 if (gameObject.CompareTag("Untagged"))
                     removableGameObjects.Add(gameObject);
                 
-                if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
-                    if (csgnode)
+                if (csgnode)
+                {
+                    if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
                         UnityEngine.Object.DestroyImmediate(csgnode);
+                    else
+                        csgnode.hideFlags |= HideFlags.HideInHierarchy | HideFlags.HideInInspector;
+                }
             }
 
-
-            if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
+            var removableTransforms = new HashSet<Transform>();
+            for (int i = 0; i < removableGameObjects.Count; i++)
             {
-                var removableTransforms = new HashSet<Transform>();
-                for (int i = 0; i < removableGameObjects.Count; i++)
-                {
-                    var gameObject = removableGameObjects[i];
-                    var transform = gameObject.transform;
-                    if (removableTransforms.Contains(transform))
-                        continue;
+                var gameObject = removableGameObjects[i];
+                var transform = gameObject.transform;
+                if (removableTransforms.Contains(transform))
+                    continue;
+                if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
                     RemoveWithChildrenIfPossible(transform, removableTransforms);
-                }
             }
         }
 

--- a/Plugins/Editor/Scripts/Control/Managers/MeshInstanceManager.Build.cs
+++ b/Plugins/Editor/Scripts/Control/Managers/MeshInstanceManager.Build.cs
@@ -130,16 +130,20 @@ namespace InternalRealtimeCSG
                     }
                 }
 
-                UnityEngine.Object.DestroyImmediate(meshContainer);
+                if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
+                    UnityEngine.Object.DestroyImmediate(meshContainer);
             }
 
 
-            var meshInstances = SceneQueryUtility.GetAllComponentsInScene<GeneratedMeshInstance>(currentScene);
-            foreach (var meshInstance in meshInstances)
+            if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
             {
-                if (meshInstance)
+                var meshInstances = SceneQueryUtility.GetAllComponentsInScene<GeneratedMeshInstance>(currentScene);
+                foreach (var meshInstance in meshInstances)
                 {
-                    UnityEngine.Object.DestroyImmediate(meshInstance);
+                    if (meshInstance)
+                    {
+                        UnityEngine.Object.DestroyImmediate(meshInstance);
+                    }
                 }
             }
 
@@ -173,18 +177,24 @@ namespace InternalRealtimeCSG
                 } else
                 if (gameObject.CompareTag("Untagged"))
                     removableGameObjects.Add(gameObject);
-                if (csgnode)
-                    UnityEngine.Object.DestroyImmediate(csgnode);
+                
+                if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
+                    if (csgnode)
+                        UnityEngine.Object.DestroyImmediate(csgnode);
             }
 
-            var removableTransforms = new HashSet<Transform>();
-            for (int i = 0; i < removableGameObjects.Count; i++)
+
+            if (CSGProjectSettings.Instance.SaveMeshesInSceneFiles || !EditorApplication.isPlayingOrWillChangePlaymode)
             {
-                var gameObject = removableGameObjects[i];
-                var transform = gameObject.transform;
-                if (removableTransforms.Contains(transform))
-                    continue;
-                RemoveWithChildrenIfPossible(transform, removableTransforms);
+                var removableTransforms = new HashSet<Transform>();
+                for (int i = 0; i < removableGameObjects.Count; i++)
+                {
+                    var gameObject = removableGameObjects[i];
+                    var transform = gameObject.transform;
+                    if (removableTransforms.Contains(transform))
+                        continue;
+                    RemoveWithChildrenIfPossible(transform, removableTransforms);
+                }
             }
         }
 

--- a/Plugins/Editor/Scripts/View/GUI/PreferenceWindows/CSGOptions.PreferenceWindow.cs
+++ b/Plugins/Editor/Scripts/View/GUI/PreferenceWindows/CSGOptions.PreferenceWindow.cs
@@ -54,10 +54,20 @@ namespace RealtimeCSG
         {
             EditorGUI.BeginChangeCheck();
             {
-                CSGProjectSettings.Instance.SaveMeshesInSceneFiles = EditorGUILayout.ToggleLeft("Save Meshes In Scene Files", CSGProjectSettings.Instance.SaveMeshesInSceneFiles);
-                EditorGUILayout.HelpBox(
-                    "If disabled, meshes will be automatically rebuilt on editor & scene load, dramatically saving disk space.",
-                    MessageType.Info, true);
+                CSGProjectSettings.Instance.SaveMeshesInSceneFiles = !EditorGUILayout.ToggleLeft("[Experimental] Don't Save Meshes In Scene Files", !CSGProjectSettings.Instance.SaveMeshesInSceneFiles);
+
+                if (!CSGProjectSettings.Instance.SaveMeshesInSceneFiles)
+                {
+                    EditorGUILayout.HelpBox(
+                        "Meshes will be rebuilt on editor & scene load. This is an experimental option, if meshes are not rebuilding properly, please disable it.",
+                        MessageType.Warning, true);
+                }
+                else
+                {
+                    EditorGUILayout.HelpBox(
+                        "If enabled, meshes will be automatically rebuilt on editor & scene load, dramatically saving disk space.",
+                        MessageType.Info, true);
+                }
 
                 CSGProjectSettings.Instance.SnapEverythingTo0001Grid = EditorGUILayout.ToggleLeft("Snap All CSG Objects To 0.001 Grid", CSGProjectSettings.Instance.SnapEverythingTo0001Grid);
                 EditorGUILayout.HelpBox(


### PR DESCRIPTION
Added [Experimental] warning to SaveMeshesInScene since it doesn't seem to work 100% of the time. Also reversed the checkbox logic so it's something that's being ENABLED rather than being DISABLED.

Thank `gawi.#0145` for letting me know that it DOES have problems. Since I've been using it for 3 months and had none, but seemingly it acts weirdly (doesn't always regenerate the meshes). This MIGHT be due to them running on Unity 2020.3. Haven't had chance to investigate.

Flipping the toggle does make sense regardless, for the sake of UX. Enabling a feature rather than disabling the default.